### PR TITLE
Add nested location blocks for cache headers

### DIFF
--- a/config/symposium.conf
+++ b/config/symposium.conf
@@ -17,10 +17,12 @@ server {
     }
 
     location /2017 {
+        include /etc/nginx/defaults/caching.conf;
         proxy_pass https://symposium.k8s.chnet/2017;
     }
 
     location / {
+        include /etc/nginx/defaults/caching.conf;
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" always;
 
         proxy_set_header Host $host;

--- a/defaults/caching.conf
+++ b/defaults/caching.conf
@@ -1,0 +1,11 @@
+location ~* \.(jpg|JPG|jpeg|png|gif|swf|svg|json)$ {
+    add_header Pragma public;
+    add_header Cache-Control "public";
+    expires 7d;
+}
+
+location ~* \.(txt|xml|js|css|md|html)$ {
+    add_header Pragma public;
+    add_header Cache-Control "public";
+    expires 1d;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./config:/etc/nginx/conf.d/:ro
       - ./shared:/etc/nginx/shared/:ro
+      - ./defaults:/etc/nginx/defaults/:ro
       - ./ssl:/etc/nginx/ssl/:ro
       - /srv/www:/srv/www:ro
       - /etc/letsencrypt:/etc/letsencrypt:ro
-


### PR DESCRIPTION
So, overloading of locations breaks everything. However, if we include the configuration inside the server blocks, it should work. At least, it works when I tested it in the symposium docker container. Could you test this on the symposium website to see if it works?