### PR TITLE
Add security headers for LANcie

### DIFF
--- a/config/lancie.conf
+++ b/config/lancie.conf
@@ -13,6 +13,27 @@ server {
     location / {
         proxy_pass https://frontend.lancie.k8s.chnet;
     }
+    
+    # add Content-Security-Policy to prevent XSS attacks
+    add_header Content-Security-Policy "
+      default-src https:;
+      script-src 'self' 'unsafe-inline' 'unsafe-eval' data: *.fbcdn.net *.facebook.com *.gstatic.com maps.googleapis.com *.google-analytics.com;
+      img-src 'self' *.fbcdn.net *.gstatic.com maps.googleapis.com;
+      style-src 'self' 'unsafe-inline' *.fbcdn.net fonts.googleapis.com;
+      font-src 'self' fonts.googleapis.com fonts.gstatic.com;
+      object-src 'none';
+      frame-ancestors 'none'";
+
+    # add X-XSS-Protection to prevent XSS attacks
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # add X-Frame-Options to prevent clickjacking attacks
+    add_header X-Frame-Options "SAMEORIGIN";
+
+    # add X-Content-Type-Options to prevent drive-by-download attacks
+    add_header X-Content-Type-Options "nosniff" always;
+
+    add_header Referrer-Policy 'no-referrer';
 }
 
 server {


### PR DESCRIPTION
Per https://securityheaders.io/?q=areafiftylan.nl&followRedirects=on we could add some more headers. I tested this configuration locally with our Docker instance, but would be great if we could test this on our staging environment for a bit as well.

CC @skamoen @martijnjanssen